### PR TITLE
fix(pod): Controller pod memory increased

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -48,9 +48,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 512Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The pod memory set was too low and as a consequence the controller container was being killed by the system (OpenShift) when processing the CR because it was running out-of-memory (OOM) while it tried to synchronize the cache. It was being killed while processing the cache in https://github.com/kubernetes/client-go/blob/master/tools/cache/shared_informer.go#L257.

This was not failing on IBM Kubernetes Service (IKS).